### PR TITLE
Use difference lists rather than reversing a list

### DIFF
--- a/quiver-cell.cabal
+++ b/quiver-cell.cabal
@@ -37,4 +37,5 @@ library
   exposed-modules:  Control.Quiver.Cell
   build-depends:    base        >= 4.8 && < 5,
                     data-cell   >= 1.0.0.2,
+                    dlist       >= 0.5 && < 0.8,
                     quiver      >= 0.0.0.11

--- a/src/Control/Quiver/Cell.lhs
+++ b/src/Control/Quiver/Cell.lhs
@@ -20,20 +20,21 @@
 > --   with each row represented by a non-empty list of cell values.
 
 > toRows :: (Monoid a, Functor f) => SP (Cell a) [a] f e
-> toRows = loop0 >->> sppure D.toList >&> fst
+> toRows = loop0
 >  where
 >   loop0 = consume () (loop2 D.empty D.empty) (deliver SPComplete)
 >
->   loop1 row cell = consume () (loop2 row cell) (spemit (assemble row cell))
+>   loop1 row cell = consume () (loop2 row cell) (spemit (assembleComplete row cell))
 >
 >   loop2 row cell (Cell part d) =
 >     case d of
 >       EOP -> loop1 row cell'
 >       EOC -> loop1 (row `D.snoc` mconcat (D.toList cell')) D.empty
->       _   -> assemble row cell' >:> loop0
+>       _   -> assembleComplete row cell' >:> loop0
 >    where
 >     cell' = cell `D.snoc` part
 >   assemble row cell = row `D.snoc` mconcat (D.toList cell)
+>   assembleComplete row = D.toList . assemble row
 
 > -- | A simple Quiver processor that converts a stream of rows to a stream of cells.
 > --   In this version, the final cell in the table is not marked with @EOT@ to avoid


### PR DESCRIPTION
This does put an extra constraint on toRows (and will hence require a
major version bump), but should improve performance, especially for
longer rows.
